### PR TITLE
Work around in JsonOptional class

### DIFF
--- a/src/main/java/com/sidemash/redson/JsonOptional.java
+++ b/src/main/java/com/sidemash/redson/JsonOptional.java
@@ -211,10 +211,11 @@ public class JsonOptional implements JsonValue {
     }
 
 
-    @Override
+//  @Override
     public void forEach(Consumer<? super JsonValue> action) {
         value.ifPresent(action);
     }
+
 
     @Override
     public Optional<Long> asLongOptional() {


### PR DESCRIPTION
There was a compilation problem due to the overriding of the forEach
method which is not declared in the implemented interface JsonValue.

To walkthrough this I have removed the //@override from the foreach
method.

Maybe it will be added to the JsonValue interface later…